### PR TITLE
Improve setup experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You will need **Ruby 2.7.1**, **NodeJS v10+** (and Yarn), and **PostgreSQL v10+*
 ```
 gem install bundler
 bundle install
-./bin/rails db:create db:migrate
+./bin/bootstrap
 ```
 
 Create a `.env` file in the project directory, and populate it with something like the following:

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,9 @@
+#!/bin/bash -eux
+
+cd "$(dirname "$0")"
+
+./bundle install
+./rails db:create db:migrate
+
+cd ..
+yarn install

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,11 @@ development:
 
 test:
   <<: *default
-  url: <%= ENV['DATABASE_URL'] || "postgres://#{ENV['USER']}@localhost/support_act_test" %>
+  <% if ENV['DATABASE_URL'] %>
+  url: <%= ENV['DATABASE_URL'] %>
+  <% else %>
+  database: support_act_test
+  <% end %>
 
 production:
   url: <%= ENV['DATABASE_URL'] %>

--- a/config/initializers/spotify.rb
+++ b/config/initializers/spotify.rb
@@ -1,3 +1,10 @@
 # frozen_string_literal: true
 
-RSpotify.authenticate(ENV["SPOTIFY_CLIENT_ID"], ENV["SPOTIFY_CLIENT_SECRET"])
+spotify_client_id = ENV["SPOTIFY_CLIENT_ID"]
+spotify_client_secret = ENV["SPOTIFY_CLIENT_SECRET"]
+
+if spotify_client_id && spotify_client_secret
+  RSpotify.authenticate(spotify_client_id, spotify_client_secret)
+elsif Rails.env.production?
+  raise "No spotify creds provided"
+end


### PR DESCRIPTION
I was trying to get the app running to send across a couple of little bugfixes, but took a little bit to get going.

This PR
* fixes `database.yml` to work across mac & linux (well, to work on linux, and I assume I didn't break mac)
* allow the app to boot when no spotify credentials are provided
* puts all the setup steps into one `bin/bootstrap` script