### PR TITLE
Consolidate artists and albums

### DIFF
--- a/app/lib/parsers/last_fm.rb
+++ b/app/lib/parsers/last_fm.rb
@@ -30,7 +30,7 @@ module Parsers
     attr_reader :fan
 
     def album_for(hash)
-      album = Album.find_or_initialize_by(:url => hash["url"])
+      album = Album.find_or_initialize_by(:last_fm_url => hash["url"])
 
       album.update!(
         :name   => hash["name"],
@@ -44,7 +44,7 @@ module Parsers
     end
 
     def artist_for(hash)
-      artist = Artist.find_or_initialize_by(:url => hash["url"])
+      artist = Artist.find_or_initialize_by(:last_fm_url => hash["url"])
 
       artist.update!(
         :name => hash["name"],

--- a/app/lib/parsers/last_fm.rb
+++ b/app/lib/parsers/last_fm.rb
@@ -30,28 +30,35 @@ module Parsers
     attr_reader :fan
 
     def album_for(hash)
-      album = Album.find_or_initialize_by(:last_fm_url => hash["url"])
+      album = find_or_initialize_by_url_or_name(Album, hash)
 
-      album.update!(
-        :name   => hash["name"],
-        :mbid   => mbid(nil, hash["mbid"]),
-        :image  => image(hash["image"]),
-        :images => images(hash["image"]),
-        :artist => artist_for(hash["artist"])
-      )
+      album.name          = hash["name"]
+      album.last_fm_url ||= hash["url"]
+      album.last_fm_raw   = hash
+      album.mbid          = mbid(nil, hash["mbid"])
+      album.image       ||= image(hash["image"])
+      album.artist        = artist_for(hash["artist"])
+      album.save
 
       album
     end
 
     def artist_for(hash)
-      artist = Artist.find_or_initialize_by(:last_fm_url => hash["url"])
+      artist = find_or_initialize_by_url_or_name(Artist, hash)
 
-      artist.update!(
-        :name => hash["name"],
-        :mbid => mbid(artist, hash["mbid"])
-      )
+      artist.name          = hash["name"]
+      artist.last_fm_url ||= hash["url"]
+      artist.last_fm_raw   = hash
+      artist.mbid          = mbid(artist, hash["mbid"])
+      artist.save
 
       artist
+    end
+
+    def find_or_initialize_by_url_or_name(model, hash)
+      model.find_by(:last_fm_url => hash["url"]) ||
+        model.find_by(:name => hash["name"]) ||
+        model.new(:name => hash["name"], :last_fm_url => hash["url"])
     end
 
     def image(array)

--- a/app/lib/parsers/spotify.rb
+++ b/app/lib/parsers/spotify.rb
@@ -23,27 +23,33 @@ module Parsers
     attr_reader :fan
 
     def album_for(object)
-      album = Album.find_or_initialize_by(:spotify_url => object.uri)
+      album = find_or_initialize_by_url_or_name(Album, object)
 
-      album.update!(
-        :name   => object.name,
-        :image  => image(object.images),
-        :artist => artist_for(object.artists.first),
-        :raw    => object.as_json
-      )
+      album.name          = object.name
+      album.spotify_url ||= object.uri
+      album.spotify_raw   = object.as_json
+      album.image         = image(object.images)
+      album.artist        = artist_for(object.artists.first)
+      album.save
 
       album
     end
 
     def artist_for(object)
-      artist = Artist.find_or_initialize_by(:spotify_url => object.uri)
+      artist = find_or_initialize_by_url_or_name(Artist, object)
 
-      artist.update!(
-        :name => object.name,
-        :raw  => object.as_json
-      )
+      artist.name          = object.name
+      artist.spotify_url ||= object.uri
+      artist.spotify_raw   = object.as_json
+      artist.save
 
       artist
+    end
+
+    def find_or_initialize_by_url_or_name(model, object)
+      model.find_by(:spotify_url => object.uri) ||
+        model.find_by(:name => object.name) ||
+        model.new(:name => object.name, :spotify_url => object.uri)
     end
 
     def image(array)

--- a/app/lib/parsers/spotify.rb
+++ b/app/lib/parsers/spotify.rb
@@ -23,7 +23,7 @@ module Parsers
     attr_reader :fan
 
     def album_for(object)
-      album = Album.find_or_initialize_by(:url => object.uri)
+      album = Album.find_or_initialize_by(:spotify_url => object.uri)
 
       album.update!(
         :name   => object.name,
@@ -36,7 +36,7 @@ module Parsers
     end
 
     def artist_for(object)
-      artist = Artist.find_or_initialize_by(:url => object.uri)
+      artist = Artist.find_or_initialize_by(:spotify_url => object.uri)
 
       artist.update!(
         :name => object.name,

--- a/db/migrate/20200824121128_split_artist_urls.rb
+++ b/db/migrate/20200824121128_split_artist_urls.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class SplitArtistUrls < ActiveRecord::Migration[6.0]
+  def up
+    rename_column :artists, :url, :last_fm_url
+    change_column_null :artists, :last_fm_url, true
+    add_column :artists, :spotify_url, :string, :index => true
+
+    execute <<~SQL
+      UPDATE artists
+      SET spotify_url = last_fm_url
+      WHERE last_fm_url LIKE 'spotify:%'
+    SQL
+
+    execute <<~SQL
+      UPDATE artists SET last_fm_url = NULL WHERE spotify_url IS NOT NULL
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE artists
+      SET last_fm_url = spotify_url
+      WHERE spotify_url IS NOT NULL
+    SQL
+
+    remove_column :artists, :spotify_url
+    change_column_null :artists, :last_fm_url, false
+    rename_column :artists, :last_fm_url, :url
+  end
+end

--- a/db/migrate/20200824122416_split_album_raw_data.rb
+++ b/db/migrate/20200824122416_split_album_raw_data.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SplitAlbumRawData < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :albums, :raw, :spotify_raw
+    add_column :albums, :last_fm_raw, :jsonb, :default => {}, :null => false
+  end
+end

--- a/db/migrate/20200824122726_split_artist_raw_data.rb
+++ b/db/migrate/20200824122726_split_artist_raw_data.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SplitArtistRawData < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :artists, :raw, :spotify_raw
+    add_column :artists, :last_fm_raw, :jsonb, :default => {}, :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_24_121128) do
+ActiveRecord::Schema.define(version: 2020_08_24_122726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,9 +24,10 @@ ActiveRecord::Schema.define(version: 2020_08_24_121128) do
     t.bigint "artist_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.jsonb "raw", default: {}, null: false
+    t.jsonb "spotify_raw", default: {}, null: false
     t.string "image"
     t.string "spotify_url"
+    t.jsonb "last_fm_raw", default: {}, null: false
     t.index ["artist_id"], name: "index_albums_on_artist_id"
     t.index ["identifier"], name: "index_albums_on_identifier", unique: true
     t.index ["last_fm_url"], name: "index_albums_on_last_fm_url"
@@ -39,8 +40,9 @@ ActiveRecord::Schema.define(version: 2020_08_24_121128) do
     t.string "mbid"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.jsonb "raw", default: {}, null: false
+    t.jsonb "spotify_raw", default: {}, null: false
     t.string "spotify_url"
+    t.jsonb "last_fm_raw", default: {}, null: false
     t.index ["identifier"], name: "index_artists_on_identifier", unique: true
     t.index ["last_fm_url"], name: "index_artists_on_last_fm_url"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_123414) do
+ActiveRecord::Schema.define(version: 2020_08_24_121128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_06_16_123414) do
   create_table "albums", force: :cascade do |t|
     t.uuid "identifier", null: false
     t.string "name", null: false
-    t.string "url", null: false
+    t.string "last_fm_url"
     t.string "mbid"
     t.jsonb "images", default: {}, null: false
     t.bigint "artist_id", null: false
@@ -26,21 +26,23 @@ ActiveRecord::Schema.define(version: 2020_06_16_123414) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "raw", default: {}, null: false
     t.string "image"
+    t.string "spotify_url"
     t.index ["artist_id"], name: "index_albums_on_artist_id"
     t.index ["identifier"], name: "index_albums_on_identifier", unique: true
-    t.index ["url"], name: "index_albums_on_url"
+    t.index ["last_fm_url"], name: "index_albums_on_last_fm_url"
   end
 
   create_table "artists", force: :cascade do |t|
     t.uuid "identifier", null: false
     t.string "name", null: false
-    t.string "url", null: false
+    t.string "last_fm_url"
     t.string "mbid"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "raw", default: {}, null: false
+    t.string "spotify_url"
     t.index ["identifier"], name: "index_artists_on_identifier", unique: true
-    t.index ["url"], name: "index_artists_on_url"
+    t.index ["last_fm_url"], name: "index_artists_on_last_fm_url"
   end
 
   create_table "fans", force: :cascade do |t|

--- a/lib/tasks/consolidate.rake
+++ b/lib/tasks/consolidate.rake
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength, Rails/SkipsModelValidations
+namespace :consolidate do
+  task :artists => :environment do
+    Artist.group(:name).having("count(*) > 1").pluck(:name).each do |name|
+      last_fm = Artist.where("name = ? AND last_fm_url IS NOT NULL", name).first
+      spotify = Artist.find_by(:name => name, :last_fm_url => nil)
+
+      last_fm.update!(
+        :spotify_url => spotify.spotify_url,
+        :spotify_raw => spotify.spotify_raw
+      )
+
+      Album.where(:artist_id => spotify.id).
+        update_all(:artist_id => last_fm.id)
+
+      spotify.destroy
+    end
+  end
+
+  task :albums => :environment do
+    query = Album.group(:name, :artist_id).
+      having("count(*) > 1").
+      pluck(:name, :artist_id)
+
+    query.each do |name, id|
+      last_fm = Album.where(
+        "name = ? AND artist_id = ? AND last_fm_url IS NOT NULL", name, id
+      ).first
+      spotify = Album.find_by(
+        :name => name, :artist_id => id, :last_fm_url => nil
+      )
+
+      last_fm.update!(
+        :spotify_url => spotify.spotify_url,
+        :spotify_raw => spotify.spotify_raw,
+        :image       => spotify.image
+      )
+
+      Fan.find_each do |fan|
+        fan.provider_cache_will_change!
+        fan.provider_cache["latest_album_ids"].collect! do |original_id|
+          original_id == spotify.id ? last_fm.id : original_id
+        end
+        fan.save
+      end
+
+      Purchase.where(:album_id => spotify.id).
+        update_all(:album_id => last_fm.id)
+
+      spotify.destroy
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength, Rails/SkipsModelValidations

--- a/spec/features/parsing_last_fm_data_spec.rb
+++ b/spec/features/parsing_last_fm_data_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Parsing Last.fm data" do
     Parse.call(fan)
 
     album = Album.find_by(
-      :url => "http://www.last.fm/music/Kishi+Bashi/String+Quartet+Live!"
+      :last_fm_url => "http://www.last.fm/music/Kishi+Bashi/String+Quartet+Live!"
     )
 
     expect(album).to be_present
@@ -69,13 +69,13 @@ RSpec.describe "Parsing Last.fm data" do
 
   it "updates known albums" do
     artist = Artist.create!(
-      :name => "Thelma Plum",
-      :url  => "http://www.last.fm/music/Thelma+Plum"
+      :name        => "Thelma Plum",
+      :last_fm_url => "http://www.last.fm/music/Thelma+Plum"
     )
     album = Album.create!(
-      :name   => "Better in Black",
-      :artist => artist,
-      :url    => "http://www.last.fm/music/Thelma+Plum/Better+in+Blak"
+      :name        => "Better in Black",
+      :artist      => artist,
+      :last_fm_url => "http://www.last.fm/music/Thelma+Plum/Better+in+Blak"
     )
 
     Parse.call(fan)
@@ -93,10 +93,10 @@ RSpec.describe "Parsing Last.fm data" do
     fan.reload
 
     thelma = Album.find_by(
-      :url => "http://www.last.fm/music/Thelma+Plum/Better+in+Blak"
+      :last_fm_url => "http://www.last.fm/music/Thelma+Plum/Better+in+Blak"
     )
     kishi = Album.find_by(
-      :url => "http://www.last.fm/music/Kishi+Bashi/String+Quartet+Live!"
+      :last_fm_url => "http://www.last.fm/music/Kishi+Bashi/String+Quartet+Live!"
     )
 
     expect(fan.provider_cache["latest_album_ids"]).to eq([thelma.id, kishi.id])

--- a/spec/features/parsing_spotify_data_spec.rb
+++ b/spec/features/parsing_spotify_data_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe "Parsing Spotify data" do
   it "creates unknown albums" do
     Parse.call(fan)
 
-    album = Album.find_by(:url => "spotify:album:5TrSm6l3WqUZ8NBJUydlEm")
+    album = Album.find_by(
+      :spotify_url => "spotify:album:5TrSm6l3WqUZ8NBJUydlEm"
+    )
 
     expect(album).to be_present
     expect(album.artist.name).to eq("Laura Mvula")
@@ -75,13 +77,13 @@ RSpec.describe "Parsing Spotify data" do
 
   it "updates known albums" do
     artist = Artist.create!(
-      :name => "Laura Mvula",
-      :url  => "spotify:artist:0Dy94lW3txJhWQHqNXP1BT"
+      :name        => "Laura Mvula",
+      :spotify_url => "spotify:artist:0Dy94lW3txJhWQHqNXP1BT"
     )
     album = Album.create!(
-      :name   => "Metropole Orkest",
-      :artist => artist,
-      :url    => "spotify:album:5TrSm6l3WqUZ8NBJUydlEm"
+      :name        => "Metropole Orkest",
+      :artist      => artist,
+      :spotify_url => "spotify:album:5TrSm6l3WqUZ8NBJUydlEm"
     )
 
     Parse.call(fan)
@@ -89,7 +91,7 @@ RSpec.describe "Parsing Spotify data" do
     artist.reload
     album.reload
 
-    expect(artist.raw).to_not be_empty
+    expect(artist.spotify_raw).to_not be_empty
     expect(album.name).to eq(
       "Laura Mvula with Metropole Orkest"
     )
@@ -99,7 +101,9 @@ RSpec.describe "Parsing Spotify data" do
     Parse.call(fan)
 
     fan.reload
-    album = Album.find_by(:url => "spotify:album:5TrSm6l3WqUZ8NBJUydlEm")
+    album = Album.find_by(
+      :spotify_url => "spotify:album:5TrSm6l3WqUZ8NBJUydlEm"
+    )
 
     expect(fan.provider_cache["latest_album_ids"]).to eq([album.id])
   end


### PR DESCRIPTION
Instead of having duplicate records - one for Spotify, one for Last.fm - instead, let's have single records with extra context. Related to #4.