### PR TITLE
Refactor service checks

### DIFF
--- a/app/lib/parsers/music_brainz/links.rb
+++ b/app/lib/parsers/music_brainz/links.rb
@@ -3,8 +3,11 @@
 module Parsers
   module MusicBrainz
     class Links
-      def self.call(album)
-        new(album).call
+      def self.call
+        Album.with_mbid.each_unchecked("musicbrainz") do |album|
+          new(album).call
+          sleep 1.1 # to avoid MusicBrainz rate-limits.
+        end
       end
 
       def initialize(album)
@@ -12,13 +15,10 @@ module Parsers
       end
 
       def call
-        album.musicbrainz_checked_at = Time.current
+        return if urls.blank?
 
-        if urls.present?
-          album.links_will_change!
-          album.links["musicbrainz"] = Array(urls)
-        end
-
+        album.links_will_change!
+        album.links["musicbrainz"] = Array(urls)
         album.save!
       end
 

--- a/app/lib/parsers/odesli/links.rb
+++ b/app/lib/parsers/odesli/links.rb
@@ -5,8 +5,11 @@ module Parsers
     class Links
       ODESLI_ENDPOINT = "https://api.song.link/v1-alpha.1/links"
 
-      def self.call(album)
-        new(album).call
+      def self.call
+        Album.with_spotify_url.each_unchecked("odesli") do |album|
+          new(album).call
+          sleep 1 # to avoid Odesli rate-limits.
+        end
       end
 
       def initialize(album)
@@ -14,13 +17,10 @@ module Parsers
       end
 
       def call
-        album.odesli_checked_at = Time.current
+        return if urls.blank?
 
-        if urls.present?
-          album.links_will_change!
-          album.links["odesli"] = Array(urls)
-        end
-
+        album.links_will_change!
+        album.links["odesli"] = Array(urls)
         album.save!
       end
 

--- a/app/lib/parsers/spotify/update_unknown.rb
+++ b/app/lib/parsers/spotify/update_unknown.rb
@@ -4,24 +4,26 @@ module Parsers
   module Spotify
     class UpdateUnknown
       def self.call
-        new.call
+        Album.where(:spotify_url => nil).each_unchecked("spotify") do |album|
+          new(album).call
+        end
+      end
+
+      def initialize(album)
+        @album = album
       end
 
       def call
-        unknown_albums.find_each do |album|
-          object = RSpotify::Album.search(
-            %(album:"#{album.name}" artist:"#{album.artist.name}")
-          ).first
+        object = RSpotify::Album.search(
+          %(album:"#{album.name}" artist:"#{album.artist.name}")
+        ).first
 
-          UpdateAlbum.call(object, album) unless object.nil?
-        end
+        UpdateAlbum.call(object, album) unless object.nil?
       end
 
       private
 
-      def unknown_albums
-        Album.where(:spotify_url => nil)
-      end
+      attr_reader :album
     end
   end
 end

--- a/app/models/album_service_check.rb
+++ b/app/models/album_service_check.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AlbumServiceCheck < ApplicationRecord
+  belongs_to :album
+
+  validates :service,         :presence => true
+  validates :last_checked_at, :presence => true
+
+  scope :missing_or_old, lambda { |service|
+    where("service IS NULL OR service = ?", service).
+      where("last_checked_at IS NULL or last_checked_at < ?", 3.months.ago)
+  }
+
+  def self.check(album, service)
+    instance = find_or_initialize_by(
+      :album   => album,
+      :service => service
+    )
+
+    yield
+
+    instance.last_checked_at = Time.current
+    instance.save!
+  end
+end

--- a/db/migrate/20200831103744_create_album_service_checks.rb
+++ b/db/migrate/20200831103744_create_album_service_checks.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAlbumServiceChecks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :album_service_checks do |t|
+      t.references :album, :null => false, :foreign_key => true
+      t.string :service, :null => false
+      t.datetime :last_checked_at, :null => false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200831112811_remove_odesli_musicbrainz_timestamps.rb
+++ b/db/migrate/20200831112811_remove_odesli_musicbrainz_timestamps.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class RemoveOdesliMusicbrainzTimestamps < ActiveRecord::Migration[6.0]
+  # rubocop:disable Metrics/MethodLength
+  def up
+    execute <<~SQL
+      INSERT INTO album_service_checks (
+        album_id, service, last_checked_at, created_at, updated_at
+      )
+      SELECT id, 'musicbrainz', musicbrainz_checked_at, musicbrainz_checked_at,
+        musicbrainz_checked_at
+      FROM albums
+      WHERE musicbrainz_checked_at IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      INSERT INTO album_service_checks (
+        album_id, service, last_checked_at, created_at, updated_at
+      )
+      SELECT id, 'odesli', odesli_checked_at, odesli_checked_at,
+        odesli_checked_at
+      FROM albums
+      WHERE odesli_checked_at IS NOT NULL
+    SQL
+
+    remove_column :albums, :musicbrainz_checked_at
+    remove_column :albums, :odesli_checked_at
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def down
+    add_column :albums, :musicbrainz_checked_at, :datetime, :index => true
+    add_column :albums, :odesli_checked_at, :datetime, :index => true
+
+    execute <<~SQL
+      UPDATE albums
+      SET musicbrainz_checked_at = album_service_checks.last_checked_at
+      FROM album_service_checks
+      WHERE album_service_checks.album_id = albums.id
+    SQL
+
+    execute <<~SQL
+      UPDATE albums
+      SET odesli_checked_at = album_service_checks.last_checked_at
+      FROM album_service_checks
+      WHERE album_service_checks.album_id = albums.id
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_27_105639) do
+ActiveRecord::Schema.define(version: 2020_08_31_103744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "album_service_checks", force: :cascade do |t|
+    t.bigint "album_id", null: false
+    t.string "service", null: false
+    t.datetime "last_checked_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["album_id"], name: "index_album_service_checks_on_album_id"
+  end
 
   create_table "albums", force: :cascade do |t|
     t.uuid "identifier", null: false
@@ -91,6 +100,7 @@ ActiveRecord::Schema.define(version: 2020_08_27_105639) do
     t.index ["fan_id"], name: "index_purchases_on_fan_id"
   end
 
+  add_foreign_key "album_service_checks", "albums"
   add_foreign_key "albums", "artists"
   add_foreign_key "purchases", "albums"
   add_foreign_key "purchases", "fans"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_103744) do
+ActiveRecord::Schema.define(version: 2020_08_31_112811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,9 +37,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_103744) do
     t.string "image"
     t.string "spotify_url"
     t.jsonb "last_fm_raw", default: {}, null: false
-    t.datetime "musicbrainz_checked_at"
     t.json "links", default: {}, null: false
-    t.datetime "odesli_checked_at"
     t.index ["artist_id"], name: "index_albums_on_artist_id"
     t.index ["identifier"], name: "index_albums_on_identifier", unique: true
     t.index ["last_fm_url"], name: "index_albums_on_last_fm_url"

--- a/lib/tasks/albums.rake
+++ b/lib/tasks/albums.rake
@@ -7,14 +7,7 @@ namespace :albums do
   end
 
   task :links => :environment do
-    Album.unlinked_by_musicbranz.with_mbid.find_each do |album|
-      Parsers::MusicBrainz::Links.call(album)
-      sleep 1.1 # to avoid MusicBrainz rate-limits.
-    end
-
-    Album.unlinked_by_odesli.with_spotify_url.find_each do |album|
-      Parsers::Odesli::Links.call(album)
-      sleep 1 # to avoid Odesli rate-limits.
-    end
+    Parsers::MusicBrainz::Links.call
+    Parsers::Odesli::Links.call
   end
 end


### PR DESCRIPTION
Given there's a whole lot of API calls going on, and many have rate limiting, we want to avoid unnecessary requests. This can be done at a simple level with a timestamp column - like I'd already been doing for MusicBrainz and Odesli. Expanding this to Last.fm and Spotify would mean adding more timestamp columns to the Album model. So, instead let's use a separate table for all the service check timestamps, which introduces a neat generic pattern for all of the services.

The data from the services is still stored in Album, because that keeps the displaying of that data faster (no complex joins required).