### PR TITLE
Add links to artists and render homepage link

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -233,6 +233,10 @@
 
   .album-artist {
     margin-bottom: 2em;
+
+    a {
+      color: inherit;
+    }
   }
 
   &-links {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,8 @@ module ApplicationHelper
       collect { |_label, pattern| links.detect { |link| link[pattern] } }.
       compact
   end
+
+  def artist_homepage(artist)
+    artist.links.dig("musicbrainz", "official homepage")
+  end
 end

--- a/app/lib/parsers/music_brainz/album_links.rb
+++ b/app/lib/parsers/music_brainz/album_links.rb
@@ -2,7 +2,7 @@
 
 module Parsers
   module MusicBrainz
-    class Links
+    class AlbumLinks
       def self.call
         Album.with_mbid.each_unchecked("musicbrainz") do |album|
           new(album).call

--- a/app/lib/parsers/music_brainz/artist_links.rb
+++ b/app/lib/parsers/music_brainz/artist_links.rb
@@ -1,0 +1,42 @@
+module Parsers
+  module MusicBrainz
+    class ArtistLinks
+      def self.call
+        Artist.with_mbid do |artist|
+          new(artist).call
+          sleep 1.1 # to avoid MusicBrainz rate-limits.
+        end
+      end
+
+      def initialize(artist)
+        @artist = artist
+      end
+
+      def call
+        return if urls.blank?
+
+        artist.links_will_change!
+        artist.links["musicbrainz"] = urls
+        artist.save!
+      end
+
+      private
+
+      attr_reader :artist
+
+      def client
+        @client ||= ::MusicBrainz::Client.new
+      end
+
+      def release
+        @release ||= client.artist artist.mbid, :includes => "url-rels"
+      end
+
+      def urls
+        return nil if release.nil?
+
+        @urls ||= release.urls
+      end
+    end
+  end
+end

--- a/app/lib/parsers/music_brainz/artist_links.rb
+++ b/app/lib/parsers/music_brainz/artist_links.rb
@@ -4,7 +4,7 @@ module Parsers
   module MusicBrainz
     class ArtistLinks
       def self.call
-        Artist.with_mbid do |artist|
+        Artist.with_mbid.each do |artist|
           new(artist).call
           sleep 1.1 # to avoid MusicBrainz rate-limits.
         end

--- a/app/lib/parsers/music_brainz/artist_links.rb
+++ b/app/lib/parsers/music_brainz/artist_links.rb
@@ -4,7 +4,7 @@ module Parsers
   module MusicBrainz
     class ArtistLinks
       def self.call
-        Artist.with_mbid.each_unchecked("musicbrainz") do |artist|
+        Artist.with_mbid do |artist|
           new(artist).call
           sleep 1.1 # to avoid MusicBrainz rate-limits.
         end
@@ -30,14 +30,14 @@ module Parsers
         @client ||= ::MusicBrainz::Client.new
       end
 
-      def release
-        @release ||= client.artist artist.mbid, :includes => "url-rels"
+      def mb_artist
+        @mb_artist ||= client.artist artist.mbid, :includes => "url-rels"
       end
 
       def urls
-        return nil if release.nil?
+        return nil if mb_artist.nil?
 
-        @urls ||= release.urls
+        @urls ||= mb_artist.urls
       end
     end
   end

--- a/app/lib/parsers/music_brainz/artist_links.rb
+++ b/app/lib/parsers/music_brainz/artist_links.rb
@@ -4,7 +4,7 @@ module Parsers
   module MusicBrainz
     class ArtistLinks
       def self.call
-        Artist.with_mbid.each do |artist|
+        Artist.with_mbid.each_unchecked("musicbrainz") do |artist|
           new(artist).call
           sleep 1.1 # to avoid MusicBrainz rate-limits.
         end

--- a/app/lib/parsers/music_brainz/artist_links.rb
+++ b/app/lib/parsers/music_brainz/artist_links.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Parsers
   module MusicBrainz
     class ArtistLinks

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,28 +1,14 @@
 # frozen_string_literal: true
 
 class Album < ApplicationRecord
-  JOIN_CLAUSE = "LEFT OUTER JOIN album_service_checks ON " \
-    "album_id = albums.id AND service = ?"
+  include Checkable
 
   belongs_to :artist
-  has_many :album_service_checks, :dependent => :delete_all
 
   before_validation :set_identifier, :on => :create
 
   scope :with_mbid, lambda { where.not(:mbid => nil) }
   scope :with_spotify_url, lambda { where.not(:spotify_url => nil) }
-  scope :without_recent_check, lambda { |service|
-    join = sanitize_sql([JOIN_CLAUSE, service])
-    joins(join).merge(AlbumServiceCheck.missing_or_old)
-  }
-
-  def self.each_unchecked(service)
-    without_recent_check(service).find_each do |album|
-      AlbumServiceCheck.check(album, service) do
-        yield album
-      end
-    end
-  end
 
   def self.latest_for_fan(fan)
     ids = fan.provider_cache["latest_album_ids"][0..19]

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -3,6 +3,8 @@
 class Artist < ApplicationRecord
   before_validation :set_identifier, :on => :create
 
+  scope :with_mbid, lambda { where.not(:mbid => nil) }
+
   private
 
   def set_identifier

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Artist < ApplicationRecord
+  include Checkable
+
   before_validation :set_identifier, :on => :create
 
   scope :with_mbid, lambda { where.not(:mbid => nil) }

--- a/app/models/concerns/checkable.rb
+++ b/app/models/concerns/checkable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Checkable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :service_checks, :as => :checkable, :dependent => :delete_all
+
+    scope :without_recent_check, lambda { |service|
+      join = sanitize_sql([join_clause, service])
+      joins(join).merge(ServiceCheck.missing_or_old)
+    }
+  end
+
+  class_methods do
+    def each_unchecked(service)
+      without_recent_check(service).find_each do |checkable|
+        ServiceCheck.check(checkable, service) do
+          yield checkable
+        end
+      end
+    end
+
+    def join_clause
+      "LEFT OUTER JOIN service_checks ON checkable_id = " \
+        "#{table_name}.id AND checkable_type = '#{self}' AND service = ?"
+    end
+  end
+end

--- a/app/models/service_check.rb
+++ b/app/models/service_check.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class AlbumServiceCheck < ApplicationRecord
-  belongs_to :album
+class ServiceCheck < ApplicationRecord
+  belongs_to :checkable, :polymorphic => true
 
   validates :service,         :presence => true
   validates :last_checked_at, :presence => true
@@ -10,10 +10,10 @@ class AlbumServiceCheck < ApplicationRecord
     where("last_checked_at IS NULL or last_checked_at < ?", 3.months.ago)
   }
 
-  def self.check(album, service)
+  def self.check(checkable, service)
     instance = find_or_initialize_by(
-      :album   => album,
-      :service => service
+      :checkable => checkable,
+      :service   => service
     )
 
     yield

--- a/app/views/albums/_album.html.erb
+++ b/app/views/albums/_album.html.erb
@@ -5,7 +5,15 @@
 <div class="album-details">
   <div class="info">
     <h3 class="album-name"><%= album.name %></h3>
-    <h4 class="album-artist"><%= album.artist.name %></h4>
+    <h4 class="album-artist">
+      <% if artist_homepage(album.artist) %>
+        <%= link_to artist_homepage(album.artist), :target => "_blank" do %>
+          <%= album.artist.name %>
+        <% end %>
+      <% else %>
+        <%= album.artist.name %>
+      <% end %>
+    </h4>
   </div>
   <div class="album-links">
     <% purchaseable_links(album).each do |link| %>
@@ -13,11 +21,7 @@
         <span><%= purchase_link_label(link) %></span>
       <% end %>
     <% end %>
-    <% if artist_homepage(album.artist) %>
-      <%= link_to artist_homepage(album.artist), :target => "_blank", :class => "button very-small primary external" do %>
-        <span>Artist homepage</span>
-      <% end %>
-    <% end %>
+
   </div>
   <div class="album-purchase">
     <%= link_to my_album_purchases_path(album), method: :delete, remote: true, :class => "button small tertiary unpurchase" do %>

--- a/app/views/albums/_album.html.erb
+++ b/app/views/albums/_album.html.erb
@@ -13,6 +13,11 @@
         <span><%= purchase_link_label(link) %></span>
       <% end %>
     <% end %>
+    <% if artist_homepage(album.artist) %>
+      <%= link_to artist_homepage(album.artist), :target => "_blank", :class => "button very-small primary external" do %>
+        <span>Artist homepage</span>
+      <% end %>
+    <% end %>
   </div>
   <div class="album-purchase">
     <%= link_to my_album_purchases_path(album), method: :delete, remote: true, :class => "button small tertiary unpurchase" do %>

--- a/app/views/my/dashboards/show.html.erb
+++ b/app/views/my/dashboards/show.html.erb
@@ -15,7 +15,7 @@
 
     <p>These are albums you've been listening to recently, but you haven't marked as purchased. Perhaps you'd like to buy a copy (in whichever format and from whatever location you wish) to support musicians more directly?</p>
 
-    <p>(Where we've been able to find them, we provide links to Bandcamp, Apple's iTunes, and Google's Store. There's plenty of links we've not yet found though - we'll keep hunting. And if you prefer vinyl, we highly recommend supporting <a href="https://recordstoreday.com/Stores?country=select" target="_blank">your local record store</a>.)</p>
+    <p>(Where we've been able to find them, we provide links to the artist's homepage, Bandcamp, Apple's iTunes, and Google's Store. There's plenty of links we've not yet found though - we'll keep hunting. And if you prefer vinyl, we highly recommend supporting <a href="https://recordstoreday.com/Stores?country=select" target="_blank">your local record store</a>.)</p>
 
     <div class="albums">
       <% unpurchased_albums.each do |album| %>

--- a/app/views/suggestions_mailer/_album.html.erb
+++ b/app/views/suggestions_mailer/_album.html.erb
@@ -9,7 +9,15 @@
 <div class="album-details">
   <div class="info">
     <h3 class="album-name"><%= album.name %></h3>
-    <h4 class="album-artist"><%= album.artist.name %></h4>
+    <h4 class="album-artist">
+      <% if artist_homepage(album.artist) %>
+        <%= link_to artist_homepage(album.artist), :target => "_blank" do %>
+          <%= album.artist.name %>
+        <% end %>
+      <% else %>
+        <%= album.artist.name %>
+      <% end %>
+    </h4>
   </div>
   <div class="album-links">
     <% purchaseable_links(album).each do |link| %>

--- a/app/views/suggestions_mailer/suggest.html.erb
+++ b/app/views/suggestions_mailer/suggest.html.erb
@@ -5,7 +5,7 @@
 
   <p>Here are albums you've recently had on high rotation that you haven't marked as purchased. If you do buy one to support the artist, mark it as purchased and we won't suggest it again ☺️.</p>
 
-  <p>(Where we've been able to find them, we provide links to Bandcamp, Apple's iTunes, and Google's Store. There's plenty of links we've not yet found though - we'll keep hunting. And if you prefer vinyl, we highly recommend supporting <a href="https://recordstoreday.com/Stores?country=select">your local record store</a>.)</p>
+  <p>(Where we've been able to find them, we provide links to the artist's homepage, Bandcamp, Apple's iTunes, and Google's Store. There's plenty of links we've not yet found though - we'll keep hunting. And if you prefer vinyl, we highly recommend supporting <a href="https://recordstoreday.com/Stores?country=select">your local record store</a>.)</p>
 
   <div class="albums">
     <% @albums.each do |album| %>

--- a/db/migrate/20210107100239_add_links_to_artists.rb
+++ b/db/migrate/20210107100239_add_links_to_artists.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLinksToArtists < ActiveRecord::Migration[6.1]
   def change
     add_column :artists, :links, :json, :default => {}, :null => false

--- a/db/migrate/20210107100239_add_links_to_artists.rb
+++ b/db/migrate/20210107100239_add_links_to_artists.rb
@@ -1,0 +1,5 @@
+class AddLinksToArtists < ActiveRecord::Migration[6.1]
+  def change
+    add_column :artists, :links, :json, :default => {}, :null => false
+  end
+end

--- a/db/migrate/20210110035819_change_album_service_checks_to_service_checks.rb
+++ b/db/migrate/20210110035819_change_album_service_checks_to_service_checks.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ChangeAlbumServiceChecksToServiceChecks < ActiveRecord::Migration[6.1]
+  def change
+    rename_table :album_service_checks, :service_checks
+    remove_index :service_checks, [:album_id]
+    rename_column :service_checks, :album_id, :checkable_id
+    add_column :service_checks, :checkable_type, :string, :default => "Album"
+    add_index :service_checks, %i[checkable_id checkable_type],
+      :name => "index_service_checks_on_checkable"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_112811) do
+ActiveRecord::Schema.define(version: 2021_01_07_100239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_112811) do
     t.jsonb "spotify_raw", default: {}, null: false
     t.string "spotify_url"
     t.jsonb "last_fm_raw", default: {}, null: false
+    t.json "links", default: {}, null: false
     t.index ["identifier"], name: "index_artists_on_identifier", unique: true
     t.index ["last_fm_url"], name: "index_artists_on_last_fm_url"
     t.index ["mbid"], name: "index_artists_on_mbid"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,27 +2,18 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_100239) do
+ActiveRecord::Schema.define(version: 2021_01_10_035819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "album_service_checks", force: :cascade do |t|
-    t.bigint "album_id", null: false
-    t.string "service", null: false
-    t.datetime "last_checked_at", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["album_id"], name: "index_album_service_checks_on_album_id"
-  end
 
   create_table "albums", force: :cascade do |t|
     t.uuid "identifier", null: false
@@ -99,8 +90,18 @@ ActiveRecord::Schema.define(version: 2021_01_07_100239) do
     t.index ["fan_id"], name: "index_purchases_on_fan_id"
   end
 
-  add_foreign_key "album_service_checks", "albums"
+  create_table "service_checks", force: :cascade do |t|
+    t.bigint "checkable_id", null: false
+    t.string "service", null: false
+    t.datetime "last_checked_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "checkable_type", default: "Album"
+    t.index ["checkable_id", "checkable_type"], name: "index_service_checks_on_checkable"
+  end
+
   add_foreign_key "albums", "artists"
   add_foreign_key "purchases", "albums"
   add_foreign_key "purchases", "fans"
+  add_foreign_key "service_checks", "albums", column: "checkable_id"
 end

--- a/lib/tasks/albums.rake
+++ b/lib/tasks/albums.rake
@@ -7,7 +7,8 @@ namespace :albums do
   end
 
   task :links => :environment do
-    Parsers::MusicBrainz::Links.call
+    Parsers::MusicBrainz::AlbumLinks.call
+    Parsers::MusicBrainz::ArtistLinks.call
     Parsers::Odesli::Links.call
     Parsers::Bandcamp::Links.call
   end


### PR DESCRIPTION
- Fetches links from MusicBrainz by the artist mbid
- Renders a homepage link under albums if the artist has an "official homepage" link

TODO:

- Either add an `ArtistServiceCheck` model or generalise the `AlbumServiceCheck` model with a polymorphic association
- Only update links for artists without a recent check

---

The first thing I thought of when trying out Support Act was that I'd like to buy records from local record stores or the artist themselves. Now, there's no API for whether your closest record store has the album you want (could this be wrangled out of [Discogs](https://www.discogs.com/developers) somehow? Possibly, but with great difficulty). I did hope I could at least link to the artist's homepage. Turns out MusicBrainz does have that information, so I mimicked the Album update from MusicBrainz for artists, giving them a JSON links attribute too (you never know what other links might be useful, following a band on a social media can present further opportunities to support them, for example). This now renders the artist homepage if one is found in MusicBrainz data, if an mbid is available for the artist.

As per the TODO above, I wondered first whether this was a feature you'd like and if so what option you would prefer? It's been a while since I messed with a database and a polymorphic association, but that likely seems the best approach to me.

What do you think?